### PR TITLE
nestpay 3d_model hatalı şifreleme hatası giderilmesi

### DIFF
--- a/upload/system/helper/webpos/adapter/nestpay/nestpay3d_model.php
+++ b/upload/system/helper/webpos/adapter/nestpay/nestpay3d_model.php
@@ -36,8 +36,6 @@ class nestpay3DModel {
 		'failUrl'=>$failUrl,
 		'rnd'=>$rnd,
 		'hash'=>$hash,
-		'islemtipi'=>"Auth",
-		'taksit'=>$taksit,
 		'storetype'=>"3d",
 		'lang'=>"tr",
 		'currency'=>"949",


### PR DESCRIPTION
destek.est@asseco-see.com.tr adresinden hata ile ilgili gelen yanıt.

Hiddenlar içinde işlem tipi ve taksit parametresinide gönderiyorsunuz. İşlem tipi ve taksiti kaldırıp ,  işlem deneyebilir misiniz?

```
         'cv2'=>$bank['cc_cvv2'],
          'Ecom_Payment_Card_ExpDate_Year'=>$bank['cc_expire_date_year'],
          'Ecom_Payment_Card_ExpDate_Month'=>$bank['cc_expire_date_month'],
         'cardType'=>$bank['cc_type'],
         'clientid'=>$bank['nestpay_client_id'],
         'amount'=>$amount,
         'oid'=>$oid,
         'okUrl'=>$okUrl,
         'failUrl'=>$failUrl,
         'rnd'=>$rnd,
         'hash'=>$hash,
         'islemtipi'=>"Auth",
         'taksit'=>$taksit,
         'storetype'=>"3d",
         'lang'=>"tr",
         'currency'=>"949",
         'bank_id'=>$bank['bank_id']
```
